### PR TITLE
Fix incorrect variable being referenced

### DIFF
--- a/lib/Test/Mock/HTTP/Tiny.pm
+++ b/lib/Test/Mock/HTTP/Tiny.pm
@@ -69,7 +69,7 @@ sub set_mocked_data {
     }
     elsif (ref($new_mocked_data) eq 'HASH') {
         # A single item was provided
-        $mocked_data = [ { %$mocked_data } ];
+        $mocked_data = [ { %$new_mocked_data } ];
     }
     else {
         # TODO: error


### PR DESCRIPTION
Fixes https://github.com/odyniec/p5-Test-Mock-HTTP-Tiny/issues/2 where the wrong variable was being referenced.